### PR TITLE
Trigger User events when table mode is enabled or disabled

### DIFF
--- a/autoload/tablemode.vim
+++ b/autoload/tablemode.vim
@@ -97,7 +97,17 @@ function! s:SetActive(bool) "{{{2
   let b:table_mode_active = a:bool
   call s:ToggleSyntax()
   call s:ToggleMapping()
-  if b:table_mode_active | echo "table-mode enabled" | else | echo "table-mode disabled" | endif
+  if b:table_mode_active
+    augroup table_mode_enabled
+      au! User table-mode-enabled echo "table-mode enabled"
+    augroup END
+    doautocmd <nomodeline> User table-mode-enabled
+  else
+    augroup table_mode_disabled
+      au! User table-mode-disabled echo "table-mode disabled"
+    augroup END
+    doautocmd <nomodeline> User table-mode-disabled
+  endif
 endfunction
 
 function! s:ConvertDelimiterToSeparator(line, ...) "{{{2


### PR DESCRIPTION
This can be used by the user to perform custom actions when table-mode is enabled or disabled.

This has in mind vim-pandoc's use case, where we would want to toggle autoformatting depending on whether table-mode is enabled or not (see https://github.com/vim-pandoc/vim-pandoc/issues/95). With this, we could simply do

```
au User table-mode-enabled call pandoc#formatting#DisableAutoformat()
au User table-mode-disabled call pandoc#formatting#EnableAutoformat()
```
