### PR TITLE
File names incorrect for files to copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There are several ways to do this
 $ cd ~/.vim
 $ git submodule add git@github.com:dhruvasagar/vim-table-mode.git bundle/table-mode
    ```
-3. Copy autoload/todomode.vim, plugin/todo-mode.vim, doc/todo-mode.txt to
+3. Copy autoload/tablemode.vim, plugin/table-mode.vim, doc/table-mode.txt to
    respective ~/.vim/autoload/, ~/.vim/plugin and ~/.vim/doc under UNIX or 
    vimfiles/autoload/, vimfiles/plugin/ and vimfiles/doc under WINDOWS and
    restart VIM


### PR DESCRIPTION
If you're interested I made a script to install this plugin and install pathogen.  I've never installed a plugin before and for me the instructions were not very easy to follow in order to get this working. It looks like exactly what I was looking for though, so thank you very much for putting this together.

# Script for UNIX only -- not tested on OSX or Windows

# Make necessary directories
mkdir -p ~/.vim/autoload ~/.vim/bundle ~/.vim/doc ~/.vim/plugin

# Install pathogen (https://github.com/tpope/vim-pathogen)
curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim

# Install vim-table-mode plugin (https://github.com/dhruvasagar/vim-table-mode)
git clone https://github.com/dhruvasagar/vim-table-mode.git ~/.vim/bundle/vim-table-mode

# Place vim-table-mode files where they need to be
cp ~/.vim/bundle/vim-table-mode/autoload/tablemode.vim ~/.vim/autoload
cp ~/.vim/bundle/vim-table-mode/plugin/table-mode.vim ~/.vim/plugin
cp ~/.vim/bundle/vim-table-mode/doc/table-mode.txt ~/.vim/doc

# Add options to ~/.vimrc to run pathogen when vim starts
echo >> ~/.vimrc
echo \"Start pathogen manager on startup >> ~/.vimrc
echo execute pathogen\#infect\(\) >> ~/.vimrc
echo >> ~/.vimrc
echo \"Enable indent on for plugin filetypes >> ~/.vimrc
echo filetype plugin indent on >> ~/.vimrc

echo Test out vim-table-mode using :TableModeToggle or :TableModeEnable or :TableModeDisable