### PR TITLE
Mappings for tableize commands

### DIFF
--- a/doc/table-mode.txt
+++ b/doc/table-mode.txt
@@ -299,6 +299,16 @@ g:table_mode_sort_map                                      *table-mode-sort-map*
         current column. >
                 let g:table_mode_sort_map = '<Leader>ts'
 >
+g:table_mode_tableize_map                              *table-mode-tableize-map*
+        Set this to configure the mapping for converting the visual selection
+        to a table. >
+                let g:table_mode_tableize_map = '<Leader>tt'
+>
+g:table_mode_tableize_d_map                          *table-mode-tableize-d-map*
+        Set this to configure the mapping for converting the visual selection
+        to a table, asking the user for a delimiter. >
+                let g:table_mode_tableize_d_map = '<Leader>T'
+>
 g:table_mode_syntax                                          *table-mode-syntax*
         Control whether table mode should define table syntax definitions or
         not. >

--- a/plugin/table-mode.vim
+++ b/plugin/table-mode.vim
@@ -36,13 +36,15 @@ call s:SetGlobalOptDefault('table_mode_motion_right_map', ']<Bar>')
 call s:SetGlobalOptDefault('table_mode_cell_text_object_a_map', 'a<Bar>')
 call s:SetGlobalOptDefault('table_mode_cell_text_object_i_map', 'i<Bar>')
 
-call s:SetGlobalOptDefault('table_mode_realign_map', '<Leader>tr')
-call s:SetGlobalOptDefault('table_mode_delete_row_map', '<Leader>tdd')
-call s:SetGlobalOptDefault('table_mode_delete_column_map', '<Leader>tdc')
-call s:SetGlobalOptDefault('table_mode_add_formula_map', '<Leader>tfa')
-call s:SetGlobalOptDefault('table_mode_eval_formula_map', '<Leader>tfe')
-call s:SetGlobalOptDefault('table_mode_echo_cell_map', '<Leader>t?')
-call s:SetGlobalOptDefault('table_mode_sort_map', '<Leader>ts')
+call s:SetGlobalOptDefault('table_mode_realign_map', g:table_mode_map_prefix.'r')
+call s:SetGlobalOptDefault('table_mode_delete_row_map', g:table_mode_map_prefix.'dd')
+call s:SetGlobalOptDefault('table_mode_delete_column_map', g:table_mode_map_prefix.'dc')
+call s:SetGlobalOptDefault('table_mode_add_formula_map', g:table_mode_map_prefix.'fa')
+call s:SetGlobalOptDefault('table_mode_eval_formula_map', g:table_mode_map_prefix.'fe')
+call s:SetGlobalOptDefault('table_mode_echo_cell_map', g:table_mode_map_prefix.'?')
+call s:SetGlobalOptDefault('table_mode_sort_map', g:table_mode_map_prefix.'s')
+call s:SetGlobalOptDefault('table_mode_tableize_map', g:table_mode_map_prefix.'t')
+call s:SetGlobalOptDefault('table_mode_tableize_d_map', '<Leader>T')
 
 call s:SetGlobalOptDefault('table_mode_syntax', 1)
 call s:SetGlobalOptDefault('table_mode_auto_align', 1)
@@ -108,12 +110,12 @@ nnoremap <silent> <Plug>(table-mode-echo-cell) :call <SID>TableEchoCell()<CR>
 nnoremap <silent> <Plug>(table-mode-sort) :call tablemode#spreadsheet#Sort('')<CR>
 
 if !hasmapto('<Plug>(table-mode-tableize)')
-  exec "nmap" g:table_mode_map_prefix . "t <Plug>(table-mode-tableize)"
-  exec "xmap" g:table_mode_map_prefix . "t <Plug>(table-mode-tableize)"
+  exec "nmap" g:table_mode_tableize_map "<Plug>(table-mode-tableize)"
+  exec "xmap" g:table_mode_tableize_map "<Plug>(table-mode-tableize)"
 endif
 
 if !hasmapto('<Plug>(table-mode-tableize-delimiter)')
-  xmap <Leader>T <Plug>(table-mode-tableize-delimiter)
+  exec "xmap" g:table_mode_tableize_d_map "<Plug>(table-mode-tableize-delimiter)"
 endif
 
 augroup TableMode "{{{1

--- a/t/config/options.vim
+++ b/t/config/options.vim
@@ -25,6 +25,8 @@ let g:table_mode_add_formula_map = '<Leader>tfa'
 let g:table_mode_eval_formula_map = '<Leader>tfe'
 let g:table_mode_echo_cell_map = '<Leader>t?'
 let g:table_mode_sort_map = '<Leader>ts'
+let g:table_mode_tableize_map = '<Leader>tt'
+let g:table_mode_tableize_d_map = '<Leader>T'
 
 let g:table_mode_syntax = 1
 let g:table_mode_auto_align = 1


### PR DESCRIPTION
Since I had `<leader>T` and `<leader>t` mapped already in my .vimrc, I wanted a simple setting to customize the table-mode mappings. This is straightforward for `<leader>T` with the variable `g:table_mode_tableize_d_map`.

I also made the default mappings use the value of `g:table_mode_map_prefix`, so it's possible to change the prefix for all table-mode commands without having to set all the other map variables. (This doesn't change the defaults in any way unless the user overrides the prefix.)