### PR TITLE
Disable/restore foldmethod during realignment

### DIFF
--- a/autoload/tablemode/table.vim
+++ b/autoload/tablemode/table.vim
@@ -166,6 +166,9 @@ function! tablemode#table#AddBorder(line) "{{{2
 endfunction
 
 function! tablemode#table#Realign(line) "{{{2
+  let current_fm = &foldmethod " save foldmethod to be restored
+  setlocal foldmethod=manual " manual foldmethod while table is being aligned
+
   let line = tablemode#utils#line(a:line)
 
   let lines = []
@@ -200,4 +203,7 @@ function! tablemode#table#Realign(line) "{{{2
   for bline in blines
     call tablemode#table#AddBorder(bline)
   endfor
+
+  " restore foldmethod
+  execute "setlocal foldmethod=" . current_fm
 endfunction


### PR DESCRIPTION
During realignment, folds are recalculated multiple times --- once for *each* line set via "``setline()``". When ``foldmethod==expr`` and the expression is difficult to calculate (e.g., pandoc/restructuredtext), the performance hit is incredible, especially on tables with many lines.

A simple fix is to suspend fold calculation while the table is being composed. This patch simply saves the ``foldmethod`` before realignment, switches it to "manual", carries out the realignment, and then restores the foldmethod again.

With this even very large tables combined with very expensive fold expression calculations are still performant.