### PR TITLE
Only insert borders on blank/whitespace-only lines

### DIFF
--- a/autoload/tablemode.vim
+++ b/autoload/tablemode.vim
@@ -170,7 +170,7 @@ endfunction
 
 function! tablemode#TableizeInsertMode() "{{{2
   if tablemode#IsActive()
-    if getline('.') =~# (tablemode#table#StartExpr() . g:table_mode_separator . g:table_mode_separator)
+    if getline('.') =~# (tablemode#table#StartExpr() . g:table_mode_separator . g:table_mode_separator) . tablemode#table#EndExpr() 
       call tablemode#table#AddBorder('.')
       normal! A
     elseif getline('.') =~# (tablemode#table#StartExpr() . g:table_mode_separator)

--- a/autoload/tablemode.vim
+++ b/autoload/tablemode.vim
@@ -170,7 +170,7 @@ endfunction
 
 function! tablemode#TableizeInsertMode() "{{{2
   if tablemode#IsActive()
-    if getline('.') =~# (tablemode#table#StartExpr() . g:table_mode_separator . g:table_mode_separator) . tablemode#table#EndExpr() 
+    if getline('.') =~# (tablemode#table#StartExpr() . g:table_mode_separator . g:table_mode_separator . tablemode#table#EndExpr()) 
       call tablemode#table#AddBorder('.')
       normal! A
     elseif getline('.') =~# (tablemode#table#StartExpr() . g:table_mode_separator)


### PR DESCRIPTION
Fixes #45.

Require our end expr to insert a border. This prevents borders from
clobbering other text and makes it possible to use visual block to insert
a new column.

I'm not a heavy table-mode user, but it's working very well for me.