### PR TITLE
Automatically setup table options

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ To get ReST-compatible tables use
     | Sherlock Holmes | 221B Baker Street        | 0987654321 |
     +-----------------+--------------------------+------------+
 
+Markdown and ReST filetypes have automatically configured corners.
 
    You can also define in a table header border how it's content should be
    aligned, whether center, right or left by using a `:` character defined by

--- a/autoload/tablemode/align.vim
+++ b/autoload/tablemode/align.vim
@@ -67,7 +67,9 @@ function! tablemode#align#alignments(lnum, ncols) "{{{2
   let achr = g:table_mode_align_char
   let alignments = []
   if tablemode#table#IsBorder(a:lnum+1)
-    let hcols = tablemode#align#Split(getline(a:lnum+1), '[' . g:table_mode_corner . g:table_mode_corner_corner . ']')
+    let corner = tablemode#utils#get_buffer_or_global_option('table_mode_corner')
+    let corner_corner = tablemode#utils#get_buffer_or_global_option('table_mode_corner_corner')
+    let hcols = tablemode#align#Split(getline(a:lnum+1), '[' . corner . corner_corner . ']')
     for idx in range(len(hcols))
       " Right align if header
       call add(alignments, 'l')

--- a/autoload/tablemode/table.vim
+++ b/autoload/tablemode/table.vim
@@ -4,16 +4,21 @@ function! s:blank(string) "{{{2
 endfunction
 
 function! s:BorderExpr() "{{{2
+  let corner = tablemode#utils#get_buffer_or_global_option('table_mode_corner')
+  let corner_corner = tablemode#utils#get_buffer_or_global_option('table_mode_corner_corner')
+  let header_fillchar = tablemode#utils#get_buffer_or_global_option('table_mode_header_fillchar')
   return tablemode#table#StartExpr() .
-        \ '[' . g:table_mode_corner . g:table_mode_corner_corner . ']' .
-        \ '[' . escape(g:table_mode_fillchar . g:table_mode_header_fillchar . g:table_mode_corner . g:table_mode_align_char, '-') . ']\+' .
-        \ '[' . g:table_mode_corner . g:table_mode_corner_corner . ']' .
+        \ '[' . corner . corner_corner . ']' .
+        \ '[' . escape(g:table_mode_fillchar . header_fillchar . corner . g:table_mode_align_char, '-') . ']\+' .
+        \ '[' . corner . corner_corner . ']' .
         \ tablemode#table#EndExpr()
 endfunction
 
 function! s:DefaultBorder() "{{{2
   if tablemode#IsActive()
-    return g:table_mode_corner_corner . g:table_mode_fillchar . g:table_mode_corner . g:table_mode_fillchar . g:table_mode_corner_corner
+    let corner = tablemode#utils#get_buffer_or_global_option('table_mode_corner')
+    let corner_corner = tablemode#utils#get_buffer_or_global_option('table_mode_corner_corner')
+    return corner_corner . g:table_mode_fillchar . corner . g:table_mode_fillchar . corner_corner
   else
     return ''
   endif
@@ -31,20 +36,24 @@ function! s:GenerateHeaderBorder(line) "{{{2
     endif
     if tablemode#utils#strlen(line_val) <= 1 | return s:DefaultBorder() | endif
 
+    let corner = tablemode#utils#get_buffer_or_global_option('table_mode_corner')
+    let corner_corner = tablemode#utils#get_buffer_or_global_option('table_mode_corner_corner')
+    let header_fillchar = tablemode#utils#get_buffer_or_global_option('table_mode_header_fillchar')
+
     let tline = line_val[stridx(line_val, g:table_mode_separator):strridx(line_val, g:table_mode_separator)]
-    let fillchar = tablemode#table#IsHeader(line - 1) ? g:table_mode_header_fillchar : g:table_mode_fillchar
+    let fillchar = tablemode#table#IsHeader(line - 1) ? header_fillchar : g:table_mode_fillchar
 
     let special_replacement = '___'
     let border = substitute(tline, g:table_mode_escaped_separator_regex, special_replacement, 'g')
     let seperator_match_regex = special_replacement . '\zs\(.\{-}\)\ze' . special_replacement
     let border = substitute(border, seperator_match_regex, '\=repeat(fillchar, tablemode#utils#StrDisplayWidth(submatch(0)))', 'g')
     let border = substitute(border, special_replacement, g:table_mode_separator, 'g')
-    let border = substitute(border, g:table_mode_separator, g:table_mode_corner, 'g')
-    let border = substitute(border, '^' . g:table_mode_corner . '\(.*\)' . g:table_mode_corner . '$', g:table_mode_corner_corner . '\1' . g:table_mode_corner_corner, '')
+    let border = substitute(border, g:table_mode_separator, corner, 'g')
+    let border = substitute(border, '^' . corner . '\(.*\)' . corner . '$', corner_corner . '\1' . corner_corner, '')
 
     " Incorporate header alignment chars
     if getline(line) =~# g:table_mode_align_char
-      let pat = '[' . g:table_mode_corner_corner . g:table_mode_corner . ']'
+      let pat = '[' . corner_corner . corner . ']'
       let hcols = tablemode#align#Split(getline(line), pat)
       let gcols = tablemode#align#Split(border, pat)
 

--- a/autoload/tablemode/utils.vim
+++ b/autoload/tablemode/utils.vim
@@ -47,3 +47,7 @@ function! tablemode#utils#StrDisplayWidth(string) "{{{2
     return rv
   endif
 endfunction
+
+function! tablemode#utils#get_buffer_or_global_option(table_option)
+  return get(b:, a:table_option, get(g:, a:table_option))
+endf

--- a/doc/table-mode.txt
+++ b/doc/table-mode.txt
@@ -185,6 +185,9 @@ g:table_mode_corner					*table-mode-corner*
 	Use this option to define the table corner character: >
 		let g:table_mode_corner = '+'
 <
+        Or only in the current buffer: >
+		let b:table_mode_corner = '+'
+<
 g:table_mode_separator					*table-mode-separator*
 	Use this option to define the table column separator character: >
 		let g:table_mode_separator = '|'
@@ -232,6 +235,9 @@ g:table_mode_corner_corner                           *table-mode-corner-corner*
         Use this option to define the character to be used for the extreme
         corners of the table border. >
                 let g:table_mode_corner_corner = '|'
+<
+        Or only in the current buffer: >
+		let b:table_mode_corner_corner = '|'
 <
 g:table_mode_align_char                                  *table-mode-align-char*
         Use this option to define the character to be used for defining

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -1,0 +1,1 @@
+let g:table_mode_corner = '|'

--- a/ftplugin/rst.vim
+++ b/ftplugin/rst.vim
@@ -1,0 +1,2 @@
+let b:table_mode_corner_corner = '+'
+let b:table_mode_header_fillchar = '='


### PR DESCRIPTION
Readme mentions settings for Markdown and ReST, but we can apply them
automatically for the current filetype.

If a user is editing a no
filetype scratch buffer, they'll still need to configure these options
themselves. But this provides better defaults when editing a buffer of
these filetypes.

Adds get_buffer_or_global_option that could be used for any other
buffer-local (filetype-specific) options.