### PR TITLE
Handle separator map and map target separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.5.3
+  - 3.0.0
 script: rake ci

--- a/autoload/tablemode.vim
+++ b/autoload/tablemode.vim
@@ -22,13 +22,9 @@ function! s:UnMap(map, mode) "{{{2
 endfunction
 
 function! s:ToggleMapping() "{{{2
-  let separator_map = g:table_mode_separator
-  " '|' is a special character, we need to map <Bar> instead
-  if g:table_mode_separator ==# '|' | let separator_map = '<Bar>' | endif
-
   if !g:table_mode_disable_mappings
     if tablemode#IsActive()
-      call s:Map('<Plug>(table-mode-tableize)', separator_map, 'i')
+      call s:Map('<Plug>(table-mode-tableize)', g:table_mode_separator_map, 'i')
       call s:Map('<Plug>(table-mode-motion-up)', g:table_mode_motion_up_map, 'n')
       call s:Map('<Plug>(table-mode-motion-down)', g:table_mode_motion_down_map, 'n')
       call s:Map('<Plug>(table-mode-motion-left)', g:table_mode_motion_left_map, 'n')
@@ -47,7 +43,7 @@ function! s:ToggleMapping() "{{{2
       call s:Map('<Plug>(table-mode-echo-cell)', g:table_mode_echo_cell_map, 'n')
       call s:Map('<Plug>(table-mode-sort)', g:table_mode_sort_map, 'n')
     else
-      call s:UnMap(separator_map, 'i')
+      call s:UnMap(g:table_mode_separator_map, 'i')
       call s:UnMap(g:table_mode_motion_up_map, 'n')
       call s:UnMap(g:table_mode_motion_down_map, 'n')
       call s:UnMap(g:table_mode_motion_left_map, 'n')
@@ -207,7 +203,7 @@ endfunction
 function! tablemode#TableizeRange(...) range "{{{2
   let lnum = a:firstline
   let total = (a:lastline - a:firstline + 1)
-  echom total
+  " echom total
   let cntr = 1
   while cntr <= total
     call s:Tableizeline(lnum, a:1)

--- a/doc/table-mode.txt
+++ b/doc/table-mode.txt
@@ -147,6 +147,7 @@ Overview:
 	|table-mode-verbose| ............ Notify when Enabled/Disabled.
 	|table-mode-corner| ............. Set corner character.
 	|table-mode-separator| .......... Set separator character.
+	|table-mode-separator-map| ...... Set separator mapping.
 	|table-mode-fillchar| ........... Set table border fillchar character.
 	|table-mode-header-fillchar| .... Set table header border fillchar character.
 	|table-mode-map-prefix| ......... Set prefix for table mode commands.
@@ -208,6 +209,11 @@ g:table_mode_separator					*table-mode-separator*
 <
 	This option also defines the trigger to be used to start creating a
 	table row in insert mode.
+
+g:table_mode_separator_map			*table-mode-separator-map*
+	Use this option to define the mapping to be used for the table separator. >
+		let g:table_mode_separator_map = '<Bar>'
+<
 
 g:table_mode_fillchar					*table-mode-fillchar*
 	Use this option to define the table border fill character: >
@@ -530,4 +536,3 @@ REPORT ISSUES					      *table-mode-report-issues*
 If you discover any issues, please report them at
 http://github.com/dhruvasagar/vim-table-mode/issues.
 
- vim:tw=78:ts=8:ft=help:norl:ai:et

--- a/plugin/table-mode.vim
+++ b/plugin/table-mode.vim
@@ -18,6 +18,13 @@ endfunction
 call s:SetGlobalOptDefault('table_mode_corner', '+')
 call s:SetGlobalOptDefault('table_mode_verbose', 1)
 call s:SetGlobalOptDefault('table_mode_separator', '|')
+" '|' is a special character, we need to map <Bar> instead
+" the character to map from
+let g:table_mode_separator_map = get(g:, 'table_mode_separator_map', g:table_mode_separator)
+if g:table_mode_separator_map ==# '|' | let g:table_mode_separator_map = '<Bar>' | endif
+" the character to map to (when inserting the separator)
+let g:table_mode_separator_map_target = g:table_mode_separator
+if g:table_mode_separator_map_target ==# '|' | let g:table_mode_separator_map_target = '<Bar>' | endif
 call s:SetGlobalOptDefault('table_mode_escaped_separator_regex', '\V\C\\\@1<!'.escape(g:table_mode_separator, '\'))
 call s:SetGlobalOptDefault('table_mode_fillchar', '-')
 call s:SetGlobalOptDefault('table_mode_header_fillchar', '-')
@@ -62,19 +69,15 @@ function! s:TableEchoCell() "{{{1
 endfunction
 
 " Define Commands & Mappings {{{1
+
 if !g:table_mode_always_active "{{{2
   exec "nnoremap <silent>" g:table_mode_map_prefix . g:table_mode_toggle_map ":<C-U>call tablemode#Toggle()<CR>"
   command! -nargs=0 TableModeToggle call tablemode#Toggle()
   command! -nargs=0 TableModeEnable call tablemode#Enable()
   command! -nargs=0 TableModeDisable call tablemode#Disable()
 else
-  let table_mode_separator_map = g:table_mode_separator
-  " '|' is a special character, we need to map <Bar> instead
-  if g:table_mode_separator ==# '|' | let table_mode_separator_map = '<Bar>' | endif
-
-  execute "inoremap <silent> " . table_mode_separator_map . ' ' .
-        \ table_mode_separator_map . "<Esc>:call tablemode#TableizeInsertMode()<CR>a"
-  unlet table_mode_separator_map
+  execute "inoremap <silent> " . g:table_mode_separator_map . ' ' .
+        \ g:table_mode_separator_map_target . "<Esc>:call tablemode#TableizeInsertMode()<CR>a"
 endif
 " }}}2
 
@@ -84,9 +87,7 @@ command! TableAddFormula call tablemode#spreadsheet#formula#Add()
 command! TableModeRealign call tablemode#table#Realign('.')
 command! TableEvalFormulaLine call tablemode#spreadsheet#formula#EvaluateFormulaLine()
 
-" '|' is a special character, we need to map <Bar> instead
-if g:table_mode_separator ==# '|' | let separator_map = '<Bar>' | endif
-execute 'inoremap <silent> <Plug>(table-mode-tableize)' separator_map . '<Esc>:call tablemode#TableizeInsertMode()<CR>a'
+execute 'inoremap <silent> <Plug>(table-mode-tableize)' g:table_mode_separator_map . '<Esc>:call tablemode#TableizeInsertMode()<CR>a'
 
 nnoremap <silent> <Plug>(table-mode-tableize) :Tableize<CR>
 xnoremap <silent> <Plug>(table-mode-tableize) :Tableize<CR>

--- a/t/config/options.vim
+++ b/t/config/options.vim
@@ -1,5 +1,6 @@
 let g:table_mode_corner = '+'
 let g:table_mode_separator = '|'
+let g:table_mode_separator_map = '<Bar>'
 let g:table_mode_escaped_separator_regex = '\V\C\\\@1<!|'
 let g:table_mode_fillchar = '-'
 let g:table_mode_header_fillchar = '-'


### PR DESCRIPTION
Fixes the error mentioned in #77. Still doesn't quite Tableize properly using a custom separator, but at least setting a custom separator no longer spits an error.