### PR TITLE
Support optional newline after tables for formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,10 @@ it using `:TableModeRealign` or using the default mapping
     results.
 
   - You can directly add / manipulate formula expressions in the formula line.
-    The formula line is a commented line right after the table, beginning with
-    'tmf:' (table mode formula). eg) `# tmf: $3=$2*$1`.  You can add multiple
-    formulas on the line separated with a ';' eg) `# tmf: $3=$2*$1;$4=$3/3.14`
+    The formula line is a commented line right after the table, or optionally
+    separated from the table by a single empty line. It begins with 'tmf:'
+    (table mode formula). eg) `# tmf: $3=$2*$1`.  You can add multiple formulas on
+    the line separated with a ';' eg) `# tmf: $3=$2*$1;$4=$3/3.14`
 
   You can evaluate the formula line using `:TableEvalFormulaLine` or the
   mapping <kbd>\<Leader\>tfe</kbd> (defined by the option `g:table_mode_eval_expr_map`)

--- a/autoload/tablemode/spreadsheet/formula.vim
+++ b/autoload/tablemode/spreadsheet/formula.vim
@@ -7,6 +7,10 @@ function! s:IsHTMLComment(line) "{{{2
   return !s:IsFormulaLine(a:line) && getline(a:line) =~# '^\s*<!--'
 endfunction
 
+function! s:IsBlankLine(line) "{{{2
+  return getline(a:line) =~# '^\s*$'
+endfunction
+
 " Public Functions {{{1
 function! tablemode#spreadsheet#formula#Add(...) "{{{2
   let fr = a:0 ? a:1 : input('f=')
@@ -144,6 +148,16 @@ function! tablemode#spreadsheet#formula#EvaluateFormulaLine() "{{{2
     let fline = line + 1
     if s:IsHTMLComment(fline) | let fline += 1 | endif
     if tablemode#table#IsBorder(fline) | let fline += 1 | endif
+    if s:IsBlankLine(fline) | let fline += 1 | endif
+    while s:IsFormulaLine(fline)
+      let exprs += split(matchstr(getline(fline), matchexpr), ';')
+      let fline += 1
+    endwhile
+  elseif s:IsBlankLine('.') " We're possibly in the blank line above the formula line
+    let fline = line('.') + 1
+    let line = line('.') - 1
+    if s:IsHTMLComment(fline) | let fline += 1 | endif
+    if tablemode#table#IsBorder(line) | let line -= 1 | endif
     while s:IsFormulaLine(fline)
       let exprs += split(matchstr(getline(fline), matchexpr), ';')
       let fline += 1
@@ -153,6 +167,7 @@ function! tablemode#spreadsheet#formula#EvaluateFormulaLine() "{{{2
     let line = line('.') - 1
     while s:IsFormulaLine(line) | let fline = line | let line -= 1 | endwhile
     if s:IsHTMLComment(line) | let line -= 1 | endif
+    if s:IsBlankLine(line) | let line -= 1 | endif
     if tablemode#table#IsBorder(line) | let line -= 1 | endif
     if tablemode#table#IsRow(line)
       " let exprs = split(matchstr(getline('.'), matchexpr), ';')


### PR DESCRIPTION
Fixes #68

This allows the formula line to be evaluated, even if there is a single
empty line after the table. The "empty" line is allowed to contain
whitespace, but nothing else.

The formula will evaluate if triggered on the table, the empty line, or
the formula lines.
