### PR TITLE
fix set updatetime with auto esc insert mode

### DIFF
--- a/autoload/tablemode.vim
+++ b/autoload/tablemode.vim
@@ -135,9 +135,7 @@ endfunction
 
 function! s:ToggleOptions() "{{{2
   if tablemode#IsActive()
-    let b:old_update_time = &updatetime
-    exec 'set updatetime='.g:table_mode_update_time
-  else
+" fix crash with auto exit insert mode
     exec 'set updatetime='.get(b:, 'old_update_time', 4000)
   endif
 endfunction


### PR DESCRIPTION
i use autocmd:
` autocmd CursorHoldI * stopinsert`
it will cause set updatetime too fast (value=500) when i enable table mode. now ifix it.
