### PR TITLE
Support new option "disable_mappings"

### DIFF
--- a/doc/table-mode.txt
+++ b/doc/table-mode.txt
@@ -145,17 +145,21 @@ Formula Expressions :
 OPTIONS							*table-mode-options*
 
 Overview:
-	|table-mode-loaded| ............. Disable the plugin.
-	|table-mode-verbose| ............ Notify when Enabled/Disabled.
-	|table-mode-corner| ............. Set corner character.
-	|table-mode-separator| .......... Set separator character.
-	|table-mode-separator-map| ...... Set separator mapping.
-	|table-mode-fillchar| ........... Set table border fillchar character.
-	|table-mode-header-fillchar| .... Set table header border fillchar character.
-	|table-mode-map-prefix| ......... Set prefix for table mode commands.
-	|table-mode-toggle-map| ......... Set table mode toggle mapping.
-	|table-mode-always-active| ...... Set table mode to always enabled.
-	|table-mode-delimiter| .......... Set the delimiter for Tableize.
+        |table-mode-loaded| ............. Disable the plugin.
+        |table-mode-loaded| ............. Disable the plugin.
+        |table-mode-verbose| ............ Notify when Enabled/Disabled.
+        |table-mode-disable-mappings| ... Disable default mappings.
+        |table-mode-disable-tableize-mappings|
+                                          Disable tableize mappings.
+        |table-mode-corner| ............. Set corner character.
+        |table-mode-separator| .......... Set separator character.
+        |table-mode-separator-map| ...... Set separator mapping.
+        |table-mode-fillchar| ........... Set table border fillchar character.
+        |table-mode-header-fillchar| .... Set table header border fillchar character.
+        |table-mode-map-prefix| ......... Set prefix for table mode commands.
+        |table-mode-toggle-map| ......... Set table mode toggle mapping.
+        |table-mode-always-active| ...... Set table mode to always enabled.
+        |table-mode-delimiter| .......... Set the delimiter for Tableize.
         |table-mode-corner-corner| ...... Set the character to be used for
                                         extreme corners of the table border.
         |table-mode-align-char|.......... Set the alignment character which
@@ -198,6 +202,15 @@ g:loaded_table_mode					*table-mode-loaded*
 g:table_mode_verbose					*table-mode-verbose*
 	Use this option to disable notifications: >
 		let g:table_mode_verbose = 0
+<
+g:table_mode_disable_mappings			*table-mode-disable-mappings*
+	Use this option to disable default mappings: >
+		let g:table_mode_disable_mappings = 1
+<
+					*table-mode-disable-tableize-mappings*
+g:table_mode_disable_tableize_mappings
+	Use this option to disable tableize mappings: >
+		let g:table_mode_disable_tableize_mappings = 1
 <
 g:table_mode_corner					*table-mode-corner*
 	Use this option to define the table corner character: >

--- a/doc/table-mode.txt
+++ b/doc/table-mode.txt
@@ -145,21 +145,20 @@ Formula Expressions :
 OPTIONS							*table-mode-options*
 
 Overview:
-        |table-mode-loaded| ............. Disable the plugin.
-        |table-mode-loaded| ............. Disable the plugin.
-        |table-mode-verbose| ............ Notify when Enabled/Disabled.
-        |table-mode-disable-mappings| ... Disable default mappings.
-        |table-mode-disable-tableize-mappings|
-                                          Disable tableize mappings.
-        |table-mode-corner| ............. Set corner character.
-        |table-mode-separator| .......... Set separator character.
-        |table-mode-separator-map| ...... Set separator mapping.
-        |table-mode-fillchar| ........... Set table border fillchar character.
-        |table-mode-header-fillchar| .... Set table header border fillchar character.
-        |table-mode-map-prefix| ......... Set prefix for table mode commands.
-        |table-mode-toggle-map| ......... Set table mode toggle mapping.
-        |table-mode-always-active| ...... Set table mode to always enabled.
-        |table-mode-delimiter| .......... Set the delimiter for Tableize.
+	|table-mode-loaded| ............. Disable the plugin.
+	|table-mode-verbose| ............ Notify when Enabled/Disabled.
+	|table-mode-disable-mappings| ... Disable default mappings.
+	|table-mode-disable-tableize-mappings|
+                                        Disable tableize mappings.
+	|table-mode-corner| ............. Set corner character.
+	|table-mode-separator| .......... Set separator character.
+	|table-mode-separator-map| ...... Set separator mapping.
+	|table-mode-fillchar| ........... Set table border fillchar character.
+	|table-mode-header-fillchar| .... Set table header border fillchar character.
+	|table-mode-map-prefix| ......... Set prefix for table mode commands.
+	|table-mode-toggle-map| ......... Set table mode toggle mapping.
+	|table-mode-always-active| ...... Set table mode to always enabled.
+	|table-mode-delimiter| .......... Set the delimiter for Tableize.
         |table-mode-corner-corner| ...... Set the character to be used for
                                         extreme corners of the table border.
         |table-mode-align-char|.......... Set the alignment character which

--- a/plugin/table-mode.vim
+++ b/plugin/table-mode.vim
@@ -64,7 +64,9 @@ call s:SetGlobalOptDefault('table_mode_tableize_auto_border', 0)
 call s:SetGlobalOptDefault('table_mode_ignore_align', 0)
 
 if !g:table_mode_always_active "{{{2
-  exec "nnoremap <silent>" g:table_mode_map_prefix . g:table_mode_toggle_map ":<C-U>call tablemode#Toggle()<CR>"
+  if !g:table_mode_disable_mappings
+    exec "nnoremap <silent>" g:table_mode_map_prefix . g:table_mode_toggle_map ":<C-U>call tablemode#Toggle()<CR>"
+  endif
   command! -nargs=0 TableModeToggle call tablemode#Toggle()
   command! -nargs=0 TableModeEnable call tablemode#Enable()
   command! -nargs=0 TableModeDisable call tablemode#Disable()


### PR DESCRIPTION
I want to map all functions in my script.
But now, vim-table-mode creates all keys automatically.
