### PR TITLE
Issue #244

### DIFF
--- a/autoload/tablemode.vim
+++ b/autoload/tablemode.vim
@@ -69,10 +69,11 @@ function! s:ToggleSyntax() "{{{2
   if !g:table_mode_syntax | return | endif
 
   if tablemode#IsActive()
+    let s:table_mode_syntax_dict = tablemode#utils#get_buffer_or_global_option('table_mode_syntax_dict')
     execute 'syntax match Table'
       \ '/' . tablemode#table#StartExpr() . '\zs|.\+|\ze' . tablemode#table#EndExpr() . '/'
-      \ 'contains=' . g:TableModeSyntaxDict.contains
-      \ 'containedin=' . g:TableModeSyntaxDict.containedin
+      \ 'contains=' . s:table_mode_syntax_dict.contains
+      \ 'containedin=' . s:table_mode_syntax_dict.containedin
     syntax match TableSeparator /|/ contained
     syntax match TableColumnAlign /:/ contained
     syntax match TableBorder /[\-+]\+/ contained

--- a/autoload/tablemode.vim
+++ b/autoload/tablemode.vim
@@ -69,10 +69,10 @@ function! s:ToggleSyntax() "{{{2
   if !g:table_mode_syntax | return | endif
 
   if tablemode#IsActive()
-    exec 'syntax match Table'
-          \ '/' . tablemode#table#StartExpr() . '\zs|.\+|\ze' . tablemode#table#EndExpr() . '/'
-          \ 'contains=TableBorder,TableSeparator,TableColumnAlign,yesCell,noCell,maybeCell,redCell,greenCell,yellowCell,blueCell,whiteCell,darkCell'
-          \ 'containedin=ALL'
+    execute 'syntax match Table'
+      \ '/' . tablemode#table#StartExpr() . '\zs|.\+|\ze' . tablemode#table#EndExpr() . '/'
+      \ 'contains=' . g:TableModeSyntaxDict.contains
+      \ 'containedin=' . g:TableModeSyntaxDict.containedin
     syntax match TableSeparator /|/ contained
     syntax match TableColumnAlign /:/ contained
     syntax match TableBorder /[\-+]\+/ contained

--- a/plugin/table-mode.vim
+++ b/plugin/table-mode.vim
@@ -132,5 +132,12 @@ augroup END
 " Avoiding side effects {{{1
 let &cpo = s:save_cpo
 
+" ToggleSyntax {{{1
+let g:TableModeSyntaxDict = {
+\   'contains': 'TableBorder,TableSeparator,TableColumnAlign,' .
+\               'yesCell,noCell,maybeCell,redCell,greenCell,yellowCell,blueCell,whiteCell,darkCell',
+\   'containedin': 'ALL'
+\}
+
 " ModeLine {{{
 " vim: sw=2 sts=2 fdl=0 fdm=marker

--- a/plugin/table-mode.vim
+++ b/plugin/table-mode.vim
@@ -57,6 +57,12 @@ call s:SetGlobalOptDefault('table_mode_sort_map', g:table_mode_map_prefix.'s')
 call s:SetGlobalOptDefault('table_mode_tableize_map', g:table_mode_map_prefix.'t')
 call s:SetGlobalOptDefault('table_mode_tableize_d_map', '<Leader>T')
 
+call s:SetGlobalOptDefault('table_mode_syntax_dict', {
+\   'contains': 'TableBorder,TableSeparator,TableColumnAlign,' .
+\               'yesCell,noCell,maybeCell,redCell,greenCell,yellowCell,blueCell,whiteCell,darkCell',
+\   'containedin': 'ALL'
+\})
+
 call s:SetGlobalOptDefault('table_mode_syntax', 1)
 call s:SetGlobalOptDefault('table_mode_auto_align', 1)
 call s:SetGlobalOptDefault('table_mode_update_time', 500)
@@ -131,13 +137,6 @@ augroup TableMode "{{{1
 augroup END
 " Avoiding side effects {{{1
 let &cpo = s:save_cpo
-
-" ToggleSyntax {{{1
-let g:table_mode_syntax_dict = {
-\   'contains': 'TableBorder,TableSeparator,TableColumnAlign,' .
-\               'yesCell,noCell,maybeCell,redCell,greenCell,yellowCell,blueCell,whiteCell,darkCell',
-\   'containedin': 'ALL'
-\}
 
 " ModeLine {{{
 " vim: sw=2 sts=2 fdl=0 fdm=marker

--- a/plugin/table-mode.vim
+++ b/plugin/table-mode.vim
@@ -133,7 +133,7 @@ augroup END
 let &cpo = s:save_cpo
 
 " ToggleSyntax {{{1
-let g:TableModeSyntaxDict = {
+let g:table_mode_syntax_dict = {
 \   'contains': 'TableBorder,TableSeparator,TableColumnAlign,' .
 \               'yesCell,noCell,maybeCell,redCell,greenCell,yellowCell,blueCell,whiteCell,darkCell',
 \   'containedin': 'ALL'


### PR DESCRIPTION
https://github.com/dhruvasagar/vim-table-mode/issues/244

Test with next VIMRC settings:
```vimrc
let g:table_mode_color_cells = 1
function! g:TableModeColorCellsCustom()
  let g:TableModeSyntaxDict.contains .= ',highPriorityCell,completeCell,infoCell'
  syntax match highPriorityCell /|\@<= *\![^|]*/ contained
  syntax match completeCell /|\@<= *X[^|]*/ contained
  syntax match infoCell /|\@<= *\/\/[^|]*/ contained
endfunction
autocmd VimEnter * call timer_start(10, {-> g:TableModeColorCellsCustom()})
```

Notes:
- In `plugin/` declared the dict to auto-run and so above `autocmd VimEnter` can run to
- `call timer_start(10` seems not best option. It should just run once the plugin is loaded (idk how)
- `g:TableModeSyntaxDict.containedin` could be other than `ALL`? I just blinded copied it.
- The README might need to explain how to expand the *Highlight cells based on content*, e.g. a link to this PR
- As stayed in #244 the [docs](https://github.com/dhruvasagar/vim-table-mode/blob/master/doc/table-mode.txt) lack all info about *Highlight cells based on content*